### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,6 +2,10 @@
 # https://github.com/hashicorp/terraform-devex-repos
 name: 'Lock Threads'
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   schedule:
     - cron: '43 20 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/markeytos/terraform-provider-keytos/security/code-scanning/2](https://github.com/markeytos/terraform-provider-keytos/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the usage of the `dessant/lock-threads` action, the workflow likely requires `contents: read` and `issues: write` permissions to lock threads and manage issues. The `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
