### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-comment-triage.yml
+++ b/.github/workflows/issue-comment-triage.yml
@@ -1,6 +1,9 @@
 # DO NOT EDIT - This GitHub Workflow is managed by automation
 # https://github.com/hashicorp/terraform-devex-repos
 name: Issue Comment Triage
+permissions:
+  contents: read
+  issues: write
 
 on:
   issue_comment:


### PR DESCRIPTION
Potential fix for [https://github.com/markeytos/terraform-provider-keytos/security/code-scanning/1](https://github.com/markeytos/terraform-provider-keytos/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow edits issues or pull requests, it needs `contents: read` and `issues: write` permissions. These permissions will be applied to all jobs in the workflow unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
